### PR TITLE
Make personal number optional in auth payload

### DIFF
--- a/payload.go
+++ b/payload.go
@@ -23,7 +23,7 @@ type AuthenticationPayload struct {
 	// The personal number of the user. String 12 digits. Century must be included.
 	// If the personal number is excluded, the client must be started with
 	// the autoStartToken returned in the response.
-	PersonalNumber string `validate:"numeric" json:"personalNumber"`
+	PersonalNumber string `validate:"omitempty,numeric" json:"personalNumber,omitempty"`
 	// The user IP address as seen by RP. String, IPv4 and IPv6 is allowed.
 	EndUserIP string `validate:"ip" json:"endUserIp"`
 	// Requirements on how the auth or sign order must be performed.


### PR DESCRIPTION
Hej Nicklas! 

Hope you are doing well.

I found one small issue with the auth payload. It is stated in [the official docs](https://www.bankid.com/en/utvecklare/guider/teknisk-integrationsguide/graenssnittsbeskrivning/identifiering-underskrift) that the personal number field is optional and can be excluded from authentication requests. I tried that with the SDK and it had validation problems with such payloads. I updated the payload struct, tested it and now it worked fine. Can we make that field optional to cover both use cases? 

Thanks for investing your time in maintaining this project.